### PR TITLE
Switch Firebase to global scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,24 +95,24 @@
     <div id="toast-container" class="fixed bottom-4 right-4 z-50"></div>
 
     <script src="https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/11.6.1/firebase-storage.js"></script>
     <script src="/__/firebase/init.js"></script>
 
 <script type="module">
-    // Importaciones de Firebase
-    import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
-    import { getAuth, signInAnonymously, onAuthStateChanged, signInWithCustomToken } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js";
-    import { getFirestore, collection, addDoc, onSnapshot, doc, getDoc, updateDoc, arrayUnion, query, orderBy, where, getDocs } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
-    import { getStorage, ref, uploadBytes, getDownloadURL } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-storage.js";
+    const { getAuth, signInAnonymously, onAuthStateChanged, signInWithCustomToken } = firebase.auth;
+    const { getFirestore, collection, addDoc, onSnapshot, doc, getDoc, updateDoc, arrayUnion, query, orderBy, where, getDocs } = firebase.firestore;
+    const { getStorage, ref, uploadBytes, getDownloadURL } = firebase.storage;
 
+    const auth = getAuth();
+    const db = getFirestore();
+    const storage = getStorage();
 
     // --- URL DE TU API DE APPS SCRIPT ---
     const BIGQUERY_API_URL = 'https://script.google.com/macros/s/AKfycbz-Ix7Mh-ZdmpsJbRaq2ZdcCChHX9TjL2SEi66LhySq9DAoxcSrbEizCQL2QJBQCl1B/exec';
 
     // --- INICIALIZACIÓN DE FIREBASE ---
-    const app = initializeApp(firebaseConfig);
-    const auth = getAuth(app);
-    const db = getFirestore(app);
-    const storage = getStorage(app);
     const purchasesCollection = collection(db, `artifacts/${appId}/public/data/compras`);
 
     let userId = null;


### PR DESCRIPTION
## Summary
- load Firebase auth, firestore, and storage libraries before `/__/firebase/init.js`
- remove module imports in `index.html`
- get auth, firestore, and storage instances from the global `firebase` object

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a9e2c9a54832da1b277e002d60cf7