### PR TITLE
Implement purchase history filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,20 @@
         <!-- Sección de Historial de Compras -->
         <main id="history-section" class="bg-white p-6 md:p-8 rounded-2xl shadow-xl">
             <h2 class="text-2xl font-bold text-slate-900 mb-4">Historial de Registros</h2>
+            <div id="history-filters" class="grid grid-cols-1 md:grid-cols-5 gap-2 mb-4">
+                <input id="history-search" type="text" placeholder="Buscar" class="p-2 border rounded-md">
+                <select id="filter-sucursal" class="p-2 border rounded-md">
+                    <option value="">Todas</option>
+                </select>
+                <input id="filter-start" type="date" class="p-2 border rounded-md">
+                <input id="filter-end" type="date" class="p-2 border rounded-md">
+                <select id="filter-status" class="p-2 border rounded-md">
+                    <option value="">Todos</option>
+                    <option>Pendiente</option>
+                    <option>Recibido con Discrepancias</option>
+                    <option>Completo</option>
+                </select>
+            </div>
             <div id="history-list" class="space-y-4">
                 <!-- Indicador de carga inicial -->
                 <div id="history-loader" class="flex items-center justify-center py-10">
@@ -141,12 +155,18 @@
     let totalFacturaAI = 0;
     let imageUrls = [];
     let productCatalog = [];
+    let allPurchases = [];
 
     // --- ELEMENTOS DEL DOM ---
     const showRegisterFormBtn = document.getElementById('show-register-form-btn');
     const registerSection = document.getElementById('register-section');
     const historyList = document.getElementById('history-list');
     const historyLoader = document.getElementById('history-loader');
+    const historySearch = document.getElementById('history-search');
+    const filterSucursal = document.getElementById('filter-sucursal');
+    const filterStart = document.getElementById('filter-start');
+    const filterEnd = document.getElementById('filter-end');
+    const filterStatus = document.getElementById('filter-status');
     const detailsModal = document.getElementById('details-modal');
     const modalContainer = document.getElementById('modal-container');
     const modalTitle = document.getElementById('modal-title');
@@ -662,29 +682,82 @@
         }
     }
 
-    // Funciones de historial y detalles (sin cambios funcionales)
-     function listenToPurchases() {
+    // Funciones de historial y detalles
+    function listenToPurchases() {
         const q = query(purchasesCollection, orderBy("createdAt", "desc"));
         onSnapshot(q, (snapshot) => {
             historyLoader.classList.add('hidden');
-            if (snapshot.empty) {
-                historyList.innerHTML = '<p class="text-center text-slate-500 py-8">No hay registros de compras todavía.</p>';
-                return;
+            allPurchases = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+            populateSucursalFilter();
+            applyHistoryFilters();
+        });
+    }
+
+    function populateSucursalFilter() {
+        const options = [...new Set(allPurchases.map(p => p.sucursal).filter(Boolean))];
+        const current = filterSucursal.value;
+        filterSucursal.innerHTML = '<option value="">Todas</option>';
+        options.forEach(suc => {
+            const opt = document.createElement('option');
+            opt.value = suc;
+            opt.textContent = suc;
+            filterSucursal.appendChild(opt);
+        });
+        if (options.includes(current)) {
+            filterSucursal.value = current;
+        }
+    }
+
+    function getReceptionStatus(items = []) {
+        if (items.length === 0) return 'Pendiente';
+        const allRec = items.every(it => it.recibido);
+        const noneRec = items.every(it => !it.recibido);
+        if (allRec) return 'Completo';
+        if (noneRec) return 'Pendiente';
+        return 'Recibido con Discrepancias';
+    }
+
+    function applyHistoryFilters() {
+        const search = historySearch.value.trim().toLowerCase();
+        const sucursal = filterSucursal.value;
+        const start = filterStart.value;
+        const end = filterEnd.value;
+        const status = filterStatus.value;
+
+        const filtered = allPurchases.filter(p => {
+            if (search) {
+                const textMatch = [p.numero_factura, p.proveedor, ...(p.items || []).map(i => i.descripcion_factura || '')]
+                    .some(val => val && val.toString().toLowerCase().includes(search));
+                if (!textMatch) return false;
             }
-            historyList.innerHTML = '';
-            snapshot.forEach(doc => {
-                const purchase = doc.data();
-                const card = document.createElement('div');
-                card.className = 'border border-slate-200 p-4 rounded-lg flex justify-between items-center hover:bg-slate-50 transition-colors';
-                card.innerHTML = `
-                    <div>
-                        <p class="font-bold text-lg text-slate-800">${purchase.proveedor} <span class="font-normal text-base text-slate-500">#${purchase.numero_factura || 'N/A'}</span></p>
-                        <p class="text-sm text-slate-500">Fecha: ${purchase.fecha} | Total: $${(purchase.total || 0).toFixed(2)}</p>
-                    </div>
-                    <button data-id="${doc.id}" class="view-details-btn bg-slate-200 hover:bg-slate-300 text-slate-700 font-medium py-2 px-4 rounded-lg">Ver Detalles</button>
-                `;
-                historyList.appendChild(card);
-            });
+            if (sucursal && p.sucursal !== sucursal) return false;
+            if (start && new Date(p.fecha) < new Date(start)) return false;
+            if (end && new Date(p.fecha) > new Date(end)) return false;
+            const recStatus = getReceptionStatus(p.items || []);
+            if (status && recStatus !== status) return false;
+            return true;
+        });
+
+        renderHistory(filtered);
+    }
+
+    function renderHistory(list) {
+        if (!list.length) {
+            historyList.innerHTML = '<p class="text-center text-slate-500 py-8">No hay registros de compras todavía.</p>';
+            return;
+        }
+        historyList.innerHTML = '';
+        list.forEach(p => {
+            const card = document.createElement('div');
+            card.className = 'border border-slate-200 p-4 rounded-lg flex justify-between items-center hover:bg-slate-50 transition-colors';
+            card.innerHTML = `
+                <div>
+                    <p class="font-bold text-lg text-slate-800">${p.proveedor} <span class="font-normal text-base text-slate-500">#${p.numero_factura || 'N/A'}</span></p>
+                    <p class="text-sm text-slate-500">Fecha: ${p.fecha} | Total: $${(p.total || 0).toFixed(2)}</p>
+                </div>
+                <button data-id="${p.id}" class="view-details-btn bg-slate-200 hover:bg-slate-300 text-slate-700 font-medium py-2 px-4 rounded-lg">Ver Detalles</button>
+            `;
+            historyList.appendChild(card);
         });
     }
     
@@ -877,6 +950,11 @@
     })();
 
     showRegisterFormBtn.addEventListener('click', showRegisterForm);
+    historySearch.addEventListener('input', applyHistoryFilters);
+    filterSucursal.addEventListener('change', applyHistoryFilters);
+    filterStart.addEventListener('change', applyHistoryFilters);
+    filterEnd.addEventListener('change', applyHistoryFilters);
+    filterStatus.addEventListener('change', applyHistoryFilters);
     
     function handleCopyClave(target) {
         const clave = target.dataset.clave;


### PR DESCRIPTION
## Summary
- add search and filter controls above the purchase history list
- track purchases in `allPurchases` and filter them client‑side
- implement `applyHistoryFilters`, `renderHistory`, and helpers
- update `listenToPurchases` to populate filters and apply them
- wire up input listeners for the new controls

## Testing
- `tidy -qe index.html`

------
https://chatgpt.com/codex/tasks/task_e_688b0a8490ec832d9e3b13b58f025c02