### PR TITLE
Add fallback page and route handling

### DIFF
--- a/fallback.html
+++ b/fallback.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Página no encontrada</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-slate-100 flex items-center justify-center h-screen">
+  <div class="text-center p-6 bg-white rounded-lg shadow-md">
+    <h1 class="text-2xl font-semibold text-slate-700 mb-4">Página no encontrada</h1>
+    <p class="text-slate-500">La ruta solicitada no existe.</p>
+    <a href="#/compras_historial" class="mt-4 inline-block text-emerald-600 hover:underline">Volver al inicio</a>
+  </div>
+</body>
+</html>

--- a/framework/router-lite.js
+++ b/framework/router-lite.js
@@ -33,10 +33,10 @@ export function createRouter({ container, registry, deps, fallbackLoadContent })
     // 2) Fallback: si piden un .html, delega al app_loader
     if (!loader) {
       const looksHtml = cleanPath.endsWith('.html');
-      if (fallbackLoadContent && looksHtml) {
+      if (fallbackLoadContent) {
         container.innerHTML = '';
         // reconstruye ruta original del .html (sin hash)
-        const filename = cleanPath;               // p.ej. "compras.html"
+        const filename = looksHtml ? cleanPath : 'fallback.html';
         return fallbackLoadContent(filename);
       }
 
@@ -56,7 +56,7 @@ export function createRouter({ container, registry, deps, fallbackLoadContent })
       console.error('[router-lite] error montando app', err);
       if (fallbackLoadContent) {
         container.innerHTML = '';
-        await fallbackLoadContent('compras.html');
+        await fallbackLoadContent('fallback.html');
       } else {
         container.innerHTML = '<div class="text-center text-red-500 py-10">Error cargando app.</div>';
       }

--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
   registry,
   deps: { appState, auth, db: firestoreDb, storage: firebaseStorage, env },  
   fallbackLoadContent: async (routeOrFile) => {
-    const file = routeOrFile.endsWith('.html') ? routeOrFile : 'compras.html';
+    const file = routeOrFile.endsWith('.html') ? routeOrFile : 'fallback.html';
     await loadContent(file, contentContainer);
   }
 });

--- a/service-worker.js
+++ b/service-worker.js
@@ -9,7 +9,7 @@ const URLS_TO_CACHE = [
   '/',
   '/index.html',
   '/login.html',
-  '/compras.html',
+  '/fallback.html',
   '/app_extraccion.html',
   '/app_pedidos_movil.html',
   '/app_historial_transferencias.html',


### PR DESCRIPTION
## Summary
- Provide dedicated `fallback.html` page for unmatched routes
- Update router-lite to load fallback page on unknown routes or errors
- Adjust index and service worker to reference new fallback page

## Testing
- `node --input-type=module - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68c1e27536ac832d92fd108784393b56