### PR TITLE
docs: add service worker guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,18 @@ El despliegue se realiza en **Firebase Hosting**:
 ```bash
 firebase deploy
 ```
-El archivo [service-worker.js](service-worker.js) se encarga de la caché y actualizaciones de recursos en producción.
+
+## Service Worker
+
+El archivo [service-worker.js](service-worker.js) controla la caché del "app shell". Define la constante
+`APP_VERSION`, usada para construir el nombre del caché (`gestion-compras-cache-<versión>`). Cambiar
+este valor en cada despliegue fuerza la creación de un caché nuevo e invalida recursos antiguos.
+
+El script implementa una estrategia **network-first** para HTML, JS y CSS, lo que prioriza obtener
+los archivos más recientes de la red y solo cae al caché si no hay conexión. Para imágenes y otros
+activos estáticos utiliza **cache-first**, entregando respuestas rápidas a costa de poder servir
+contenido desactualizado.
+
+Para aplicar inmediatamente una nueva versión, la aplicación puede enviar
+`postMessage({ type: 'SKIP_WAITING' })` al Service Worker, provocando que la actualización se active
+sin esperar a que el usuario recargue manualmente.

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -26,8 +26,14 @@
   - `createDraftStore` (`framework/drafts.js`) guarda borradores en `localStorage`.
 
 ## Service Worker
-- `service-worker.js` implementa app‑shell con `CACHE_NAME`.
-- Para forzar actualización: cambiar `CACHE_NAME` o recargar con hard reload.
+- `service-worker.js` implementa el app‑shell y gestiona la caché.
+- `APP_VERSION` se concatena a un prefijo para generar `CACHE_NAME`; cambiarla en cada despliegue
+  invalida cachés antiguos.
+- Estrategias:
+  - **network-first** para HTML, JS y CSS → asegura recursos frescos con respaldo al caché.
+  - **cache-first** para imágenes y fuentes → mejora rendimiento pero puede servir contenido viejo.
+- La app puede enviar `postMessage({ type: 'SKIP_WAITING' })` al Service Worker para que la versión
+  actualizada se active inmediatamente.
 
 ## Flujo de datos e IA
 1. Usuario inicia sesión.


### PR DESCRIPTION
## Summary
- explain Service Worker versioning via `APP_VERSION`
- describe network-first vs cache-first strategies and instant activation via `SKIP_WAITING`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d56de20c832d8a2e946cd77e53ed