### PR TITLE
fix: prevent form submission when adding item

### DIFF
--- a/apps/components/items_editor.js
+++ b/apps/components/items_editor.js
@@ -104,7 +104,7 @@ export function ItemsEditor({
       <div id="ie-items-list" class="mt-4 space-y-4"></div>
 
       <div class="mt-4 flex items-center justify-between">
-        <button id="ie-add-item"
+        <button id="ie-add-item" type="button"
           class="bg-blue-500 hover:bg-blue-600 text-white font-medium py-2 px-4 rounded-lg flex items-center">
           <span class="material-icons mr-2">add</span>Añadir Artículo
         </button>


### PR DESCRIPTION
## Summary
- prevent registration form from closing by specifying type=button on add item button

## Testing
- `node - <<'NODE'
const {JSDOM}=require('jsdom');
const fs=require('fs');
const file=fs.readFileSync('apps/components/items_editor.js','utf8');
const match=file.match(/<button id="ie-add-item"[^>]*>[\s\S]*?<\/button>/);
const html=`<form id="form">${match[0]}</form>`;
const dom=new JSDOM(html);
let submitted=false;
dom.window.document.getElementById('form').addEventListener('submit',()=>{submitted=true});
dom.window.document.getElementById('ie-add-item').click();
console.log('submitted:',submitted);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68c1ec6e0d4c832da50d3c9e66060648