### PR TITLE
Enable process button on account change

### DIFF
--- a/apps/conciliacion.app.js
+++ b/apps/conciliacion.app.js
@@ -28,7 +28,10 @@ export default {
 
     // Handlers UI
     ui.tc.addEventListener('input', () => dirtyParamsBanner(ui));
-    ui.cuenta.addEventListener('change', () => dirtyParamsBanner(ui));
+    ui.cuenta.addEventListener('change', () => {
+      dirtyParamsBanner(ui);
+      maybeEnableProcess();
+    });
 
     ui.btnAlegra.addEventListener('change', async (e) => {
       alegraRows = await readAnyTable(e.target.files[0]);


### PR DESCRIPTION
## Summary
- enable process button after account dropdown selection

## Testing
- `npm test` (fails: no package.json)
- `node -e` simulation shows process button becomes enabled


------
https://chatgpt.com/codex/tasks/task_e_68c5c01324ac832da464feea7eb44204