### PR TITLE
Persist parsed data and user preferences

### DIFF
--- a/apps/lib/idb_utils.js
+++ b/apps/lib/idb_utils.js
@@ -1,0 +1,23 @@
+// apps/lib/idb_utils.js
+export const IDB_NAME = 'ff-concilia'; // DB SEPARADA de tu app
+export async function openDbEnsureStores(stores = []) {
+  let db = await new Promise((res, rej) => {
+    const req = indexedDB.open(IDB_NAME);
+    req.onsuccess = () => res(req.result);
+    req.onerror = () => rej(req.error);
+  });
+  const missing = stores.filter(s => !db.objectStoreNames.contains(s));
+  if (!missing.length) return db;
+
+  const newVersion = db.version + 1;
+  db.close();
+  return await new Promise((res, rej) => {
+    const req = indexedDB.open(IDB_NAME, newVersion);
+    req.onupgradeneeded = (ev) => {
+      const up = ev.target.result;
+      missing.forEach(s => { if (!up.objectStoreNames.contains(s)) up.createObjectStore(s); });
+    };
+    req.onsuccess = () => res(req.result);
+    req.onerror = () => rej(req.error);
+  });
+}

--- a/apps/lib/recon_storage.js
+++ b/apps/lib/recon_storage.js
@@ -1,5 +1,6 @@
 // apps/lib/recon_storage.js
 import { buildStorageKey } from './recon_config.js';
+import { openDbEnsureStores } from './idb_utils.js';
 
 export function loadSession({ cuentaId, desdeISO, hastaISO }) {
   const key = buildStorageKey({ cuentaId, desdeISO, hastaISO });
@@ -10,4 +11,33 @@ export function saveSession({ cuentaId, desdeISO, hastaISO }, stateObj) {
   const key = buildStorageKey({ cuentaId, desdeISO, hastaISO });
   localStorage.setItem(key, JSON.stringify(stateObj));
 }
+
+// ---------- Tablas parseadas ----------
+const STORE_TABLES = 'tables';
+function tablesKey({ cuentaId, desdeISO, hastaISO }) {
+  return `tables:${cuentaId}:${desdeISO || 'na'}:${hastaISO || 'na'}`;
+}
+export async function saveParsedTables({ cuentaId, desdeISO, hastaISO, alegraRows, bancoRows }) {
+  const db = await openDbEnsureStores([STORE_TABLES]);
+  const tx = db.transaction(STORE_TABLES, 'readwrite');
+  await new Promise((res, rej) => {
+    const req = tx.objectStore(STORE_TABLES).put({ alegraRows, bancoRows, ts: Date.now() }, tablesKey({ cuentaId, desdeISO, hastaISO }));
+    req.onsuccess = () => res();
+    req.onerror = () => rej(req.error);
+  });
+}
+export async function loadParsedTables({ cuentaId, desdeISO, hastaISO }) {
+  const db = await openDbEnsureStores([STORE_TABLES]);
+  const tx = db.transaction(STORE_TABLES, 'readonly');
+  return await new Promise((res) => {
+    const req = tx.objectStore(STORE_TABLES).get(tablesKey({ cuentaId, desdeISO, hastaISO }));
+    req.onsuccess = () => res(req.result || null);
+    req.onerror = () => res(null);
+  });
+}
+
+// ---------- Preferencias ----------
+const PREFS_KEY = 'conciliacion:prefs';
+export function savePrefs(p) { localStorage.setItem(PREFS_KEY, JSON.stringify(p || {})); }
+export function loadPrefs() { try { return JSON.parse(localStorage.getItem(PREFS_KEY) || '{}'); } catch { return {}; } }
 


### PR DESCRIPTION
## Summary
- add IndexedDB helper for managing conciliation storage
- persist parsed tables and user preferences in recon_storage
- load/save preferences and tables in conciliation app

## Testing
- `node --test apps/lib/*test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5f31c0760832d891597d95981a67f