### PR TITLE
refactor: extract export utilities

### DIFF
--- a/apps/conciliacion.app.js
+++ b/apps/conciliacion.app.js
@@ -6,6 +6,7 @@ import { DATE_WINDOW } from './lib/recon_config.js';
 import { bankSignature, masterBulkHas, masterSave, masterGetAll, masterImportEntries } from './lib/recon_master.js';
 import { loadSession, saveSession, saveParsedTables, loadParsedTables, savePrefs, loadPrefs } from './lib/recon_storage.js';
 import { clearCache } from './lib/mapping_cache.js'; // opcional si usás asociaciones aquí después
+import { toCSV, downloadText } from './lib/export_utils.js';
 
 function normalizeSession(s) {
   return {
@@ -449,32 +450,4 @@ function renderRightPanel(b, cands, ui, session, onFix) {
   }
 }
 
-// ====== helpers locales para export ======
-function toCSV(arr = []) {
-  const header = ['sig','cuentaId','fecha','signo','nroConfirm','montoNio','descripcion','alegraIds','meta'];
-  const esc = (v) => `"${String(v ?? '').replace(/"/g,'""')}"`;
-  const lines = [header.join(',')];
-  for (const e of arr) {
-    const row = {
-      sig: e.sig,
-      cuentaId: e.cuentaId,
-      fecha: e.fecha,
-      signo: e.signo,
-      nroConfirm: e.nroConfirm ?? '',
-      montoNio: e.montoNio,
-      descripcion: e.descripcion ?? '',
-      alegraIds: Array.isArray(e.alegraIds) ? e.alegraIds.join('|') : (e.alegraIds ?? ''),
-      meta: JSON.stringify(e.meta || {}),
-    };
-    lines.push(header.map(k => esc(row[k])).join(','));
-  }
-  return lines.join('\r\n');
-}
-function downloadText(filename, text, mime='text/plain') {
-  const blob = new Blob([text], { type: mime });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url; a.download = filename; document.body.appendChild(a); a.click(); a.remove();
-  URL.revokeObjectURL(url);
-}
 

--- a/apps/lib/export_utils.js
+++ b/apps/lib/export_utils.js
@@ -1,0 +1,32 @@
+// apps/lib/export_utils.js
+
+// Helpers for exporting data
+export function toCSV(arr = []) {
+  const header = ['sig','cuentaId','fecha','signo','nroConfirm','montoNio','descripcion','alegraIds','meta'];
+  const esc = (v) => `"${String(v ?? '').replace(/"/g,'""')}"`;
+  const lines = [header.join(',')];
+  for (const e of arr) {
+    const row = {
+      sig: e.sig,
+      cuentaId: e.cuentaId,
+      fecha: e.fecha,
+      signo: e.signo,
+      nroConfirm: e.nroConfirm ?? '',
+      montoNio: e.montoNio,
+      descripcion: e.descripcion ?? '',
+      alegraIds: Array.isArray(e.alegraIds) ? e.alegraIds.join('|') : (e.alegraIds ?? ''),
+      meta: JSON.stringify(e.meta || {}),
+    };
+    lines.push(header.map(k => esc(row[k])).join(','));
+  }
+  return lines.join('\r\n');
+}
+
+export function downloadText(filename, text, mime='text/plain') {
+  const blob = new Blob([text], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url; a.download = filename; document.body.appendChild(a); a.click(); a.remove();
+  URL.revokeObjectURL(url);
+}
+


### PR DESCRIPTION
## Summary
- factor out toCSV and downloadText helpers into apps/lib/export_utils.js
- use shared export utils in conciliacion app

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f8231268832d9dd1807ec74a4d89