### PR TITLE
refactor recon_storage utility

### DIFF
--- a/apps/lib/recon_storage.js
+++ b/apps/lib/recon_storage.js
@@ -1,6 +1,8 @@
+// recon_storage: sesión (localStorage), tablas parseadas (IndexedDB) y preferencias
 import { buildStorageKey } from './recon_config.js';
 import { openDbEnsureStores } from './idb_utils.js';
 
+// ---------- Sesión por periodo/cuenta (localStorage) ----------
 export function loadSession({ cuentaId, desdeISO, hastaISO }) {
   const key = buildStorageKey({ cuentaId, desdeISO, hastaISO });
   try { return JSON.parse(localStorage.getItem(key) || '{}'); } catch { return {}; }
@@ -11,8 +13,9 @@ export function saveSession({ cuentaId, desdeISO, hastaISO }, stateObj) {
   localStorage.setItem(key, JSON.stringify(stateObj));
 }
 
-// ---------- Tablas parseadas (IndexedDB: ff-concilia/tables) ----------
+// ---------- Tablas parseadas (IndexedDB: ff-concilia / store: tables) ----------
 const STORE_TABLES = 'tables';
+
 function tablesKey({ cuentaId, desdeISO, hastaISO }) {
   return `tables:${cuentaId}:${desdeISO || 'na'}:${hastaISO || 'na'}`;
 }
@@ -36,12 +39,15 @@ export async function loadParsedTables({ cuentaId, desdeISO, hastaISO }) {
   return await new Promise((res) => {
     const req = tx.objectStore(STORE_TABLES).get(tablesKey({ cuentaId, desdeISO, hastaISO }));
     req.onsuccess = () => res(req.result || null);
-    req.onerror = () => res(null);
+    req.onerror   = () => res(null);
   });
 }
 
-// ---------- Preferencias (localStorage) ----------
+// ---------- Preferencias de UI (localStorage) ----------
 const PREFS_KEY = 'conciliacion:prefs';
-export function savePrefs(p) { localStorage.setItem(PREFS_KEY, JSON.stringify(p || {})); }
-export function loadPrefs() { try { return JSON.parse(localStorage.getItem(PREFS_KEY) || '{}'); } catch { return {}; } }
-
+export function savePrefs(p) {
+  localStorage.setItem(PREFS_KEY, JSON.stringify(p || {}));
+}
+export function loadPrefs() {
+  try { return JSON.parse(localStorage.getItem(PREFS_KEY) || '{}'); } catch { return {}; }
+}


### PR DESCRIPTION
## Summary
- rewrite recon_storage for session management, parsed table caching, and UI preferences

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68c601cbc21c832dbf2bfa5392b17c69