### PR TITLE
Limit transfer history pages to 20 sorted by date and bank

### DIFF
--- a/apps/caja_historial.app.js
+++ b/apps/caja_historial.app.js
@@ -131,7 +131,7 @@ export default {
     let alegraContactsCache = [];
     let alegraCategoriesCache = [];
 
-    const PAGE_SIZE = 50;
+    const PAGE_SIZE = 20;
     let pageIndex = 0;                 // página actual (0-based)
     let pageCursors = [];              // [{ lastDoc, size }]
     let currentUnsub = null;           // onSnapshot actual
@@ -171,7 +171,8 @@ export default {
     function buildPageQuery({ startAfterDoc = null }) {
       let qy = query(
         transfersCollection,
-        orderBy('createdAt', 'desc'),
+        orderBy('fecha', 'desc'),
+        orderBy('banco', 'asc'),
         limit(PAGE_SIZE)
       );
       const bankId = filterBank.value;


### PR DESCRIPTION
## Summary
- Reduce transfer history page size to 20 items
- Sort records by date descending then bank name ascending

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7303d0020832da10076033f268cdb