### PR TITLE
Oculta elementos no imprimibles usando display

### DIFF
--- a/apps/caja_detalle.app.js
+++ b/apps/caja_detalle.app.js
@@ -18,10 +18,11 @@ function setupA4PrintStyles() {
 
     /* Oculta TODO excepto el detalle */
     body * {
-      visibility: hidden !important;
+      display: none !important;
     }
-    .printable-area, .printable-area * {
-      visibility: visible !important;
+    .printable-area,
+    .printable-area * {
+      display: revert !important; /* o display: initial */
     }
 
     /* Asegura que el detalle se ubique en la página dentro de los márgenes */


### PR DESCRIPTION
## Summary
- Replaced print rules to hide all body elements with `display:none`.
- Restored visibility for `.printable-area` elements with `display:revert` so only intended content prints.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `wkhtmltopdf /tmp/print-test.html /tmp/print-test.pdf`
- `pdfinfo /tmp/print-test.pdf | head -n 20`
- `pdftotext /tmp/print-test.pdf - | cat`


------
https://chatgpt.com/codex/tasks/task_e_68c74232bcf8832d8fc32aa2f89f9888