### PR TITLE
Compact caja_detalle print spacing

### DIFF
--- a/apps/caja_detalle.app.js
+++ b/apps/caja_detalle.app.js
@@ -72,11 +72,12 @@ function setupA4PrintStyles() {
     /* Grids a una sola columna para imprimir mejor */
     .printable-area .grid {
       display: block !important;
+      gap: 2mm !important;
     }
     .printable-area .grid > * {
       break-inside: avoid;
       page-break-inside: avoid;
-      margin-bottom: 4mm !important;
+      margin-bottom: 2mm !important;
     }
 
     /* Quita botones/acciones dentro del detalle si quedaran visibles */
@@ -102,7 +103,7 @@ function setupA4PrintStyles() {
     .printable-area.shrink {
       letter-spacing: 0 !important;
     }
-    .printable-area.shrink .grid > * { margin-bottom: 3mm !important; }
+    .printable-area.shrink .grid > * { margin-bottom: 1mm !important; }
     .printable-area.shrink h1,
     .printable-area.shrink h2,
     .printable-area.shrink h3 { margin-bottom: 4px !important; }


### PR DESCRIPTION
## Summary
- Tighten spacing in caja_detalle A4 print styles for more room
- Add optional grid gap override and reduce item margins

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7473afdcc832db10dd3c7e74d14e2