### PR TITLE
Reset image spacing in A4 print layout

### DIFF
--- a/apps/caja_detalle.app.js
+++ b/apps/caja_detalle.app.js
@@ -65,7 +65,7 @@ function setupA4PrintStyles() {
     /* El contenedor de la imagen se dimensiona dinámicamente en JS */
     #imgWrap {
       border: 0 !important;
-      margin: 0 0 6mm 0 !important;
+      margin: 0 !important;
       padding: 0 !important;
     }
 
@@ -73,6 +73,7 @@ function setupA4PrintStyles() {
     .printable-area .grid {
       display: block !important;
       gap: 2mm !important;
+      margin: 2mm 0 !important;
     }
     .printable-area .grid > * {
       break-inside: avoid;


### PR DESCRIPTION
## Summary
- Remove extra margin around #imgWrap in A4 print styles
- Add subtle margins to printable grid for visual separation

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c747e06d24832daa2c0956bdeb2b63