### PR TITLE
Add caja_transferir to registry

### DIFF
--- a/framework/registry.js
+++ b/framework/registry.js
@@ -7,6 +7,7 @@ export const registry = {
   'caja_detalle': () => import('../apps/caja_detalle.app.js'),
   'caja_editar':  () => import('../apps/caja_editar.app.js'),
   'caja_registrar': () => import('../apps/caja_registrar.app.js'),
+  'caja_transferir': () => import('../apps/caja_transferir.app.js'),
   'compras_historial': () => import('../apps/compras_historial.app.js'),
   'compras_registrar': () => import('../apps/compras_registrar.app.js'),
   'compras_detalles': () => import('../apps/compras_detalles.app.js'),


### PR DESCRIPTION
## Summary
- register `caja_transferir` app in registry to enable loading

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a24f6818832d9dbc389cb72d3cde