### PR TITLE
refactor: centralize toast notifications

### DIFF
--- a/app_extraccion.html
+++ b/app_extraccion.html
@@ -140,6 +140,7 @@ input[type="date"]::-webkit-calendar-picker-indicator { cursor: pointer; opacity
     import { collection, addDoc, serverTimestamp, getDocs, query, where } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
     import { ref, uploadBytes, getDownloadURL } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-storage.js";
     import { toNio } from './export_utils.js';
+    import { showToast } from './apps/lib/toast.js';
 
     // --- 1. ESTADO Y CONSTANTES GLOBALES ---
     let userId = null, currentImageUrl = null;
@@ -1053,15 +1054,6 @@ async function checkConfirmationExists(number) {
         return isNaN(n) ? null : n;
     }
     
-    function showToast(message, type = 'info') {
-        const t = document.createElement('div');
-        const c = { info: 'bg-sky-600', success: 'bg-emerald-600', warning: 'bg-amber-500', error: 'bg-red-600' };
-        t.className = `p-4 rounded-lg shadow-xl text-white font-semibold animate-pulse ${c[type]}`;
-        t.textContent = message;
-        document.getElementById('toast-container').appendChild(t);
-        setTimeout(() => t.remove(), 4000);
-    }
-
         function fileToBase64(file) { return new Promise((resolve, reject) => { const reader = new FileReader(); reader.onload = event => resolve(event.target.result); reader.onerror = error => reject(error); reader.readAsDataURL(file); }); }
 
 // Normaliza para buscar (sin acentos, minúsculas)

--- a/app_historial_transferencias.html
+++ b/app_historial_transferencias.html
@@ -77,6 +77,7 @@
     import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js";
     import { collection, onSnapshot, doc, deleteDoc, query, orderBy, serverTimestamp, getDoc, updateDoc, where, getDocs, addDoc } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
     import { toNio } from './export_utils.js';
+    import { showToast } from './apps/lib/toast.js';
 
     function initHistoryApp() {
         const transfersCollection = collection(db, 'transferencias');
@@ -485,15 +486,6 @@
             `;
         }
         
-        function showToast(message, type = 'info') { 
-            const toast = document.createElement('div');
-            const colors = { info: 'bg-sky-500', success: 'bg-emerald-500', error: 'bg-red-500' };
-            toast.className = `fixed bottom-4 right-4 z-50 ${colors[type]} text-white font-bold py-3 px-5 rounded-lg shadow-xl`;
-            toast.textContent = message;
-            document.body.appendChild(toast);
-            setTimeout(() => toast.remove(), 3000);
-        }
-
         function cleanAmount(amount) {
             if (amount === null || amount === undefined) return null;
             let amountStr = String(amount).replace(/[^\d,.]/g, '');

--- a/apps/caja_chica_historial.app.js
+++ b/apps/caja_chica_historial.app.js
@@ -9,6 +9,7 @@ import {
   limit, startAfter
 } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
 import { toNio } from '../export_utils.js';
+import { showToast } from './lib/toast.js';
 
 export default {
   async mount(container, { appState, params }) {
@@ -177,14 +178,6 @@ export default {
         modalEl.onclick = null;
       }
     }
-    function toast(message, type='info'){
-      const colors = { info:'bg-sky-500', success:'bg-emerald-500', error:'bg-red-500' };
-      const div = document.createElement('div');
-      div.className = `fixed bottom-4 right-4 ${colors[type]} text-white font-bold py-3 px-5 rounded-lg shadow-xl`;
-      div.textContent = message;
-      container.appendChild(div);
-      setTimeout(()=>div.remove(), 2500);
-    }
 
     function buildPageQuery() {
       // Para NO requerir índice compuesto:
@@ -245,7 +238,7 @@ export default {
         renderWithClientFilters();
       } catch(err){
         console.error(err);
-        toast('Error al cargar datos.', 'error');
+        showToast('Error al cargar datos.', 'error');
       }
     }
 
@@ -447,13 +440,13 @@ export default {
       if (btn.classList.contains('approve-btn')) {
         showModal('¿Aprobar este registro?', async () => {
           await updateDoc(doc(db, transfersCollection.path, id), { status: 'approved', updatedAt: serverTimestamp() });
-          toast('Registro aprobado.', 'success');
+          showToast('Registro aprobado.', 'success');
           renderWithClientFilters(); // refleja saldo si el filtro de estado aplica
         });
       } else if (btn.classList.contains('delete-btn')) {
         showModal('¿Eliminar este registro?', async () => {
           await deleteDoc(doc(db, transfersCollection.path, id));
-          toast('Registro eliminado.', 'success');
+          showToast('Registro eliminado.', 'success');
           renderWithClientFilters();
         });
       }

--- a/apps/caja_historial.app.js
+++ b/apps/caja_historial.app.js
@@ -10,6 +10,7 @@ import {
   serverTimestamp, getDoc, updateDoc, where, getDocs, addDoc,
   limit, startAfter
 } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
+import { showToast } from './lib/toast.js';
 
 export default {
   async mount(container, { appState }) {
@@ -151,14 +152,6 @@ export default {
         modalEl.onclick = null;
       }
     }
-    function toast(message, type='info'){
-      const colors = { info:'bg-sky-500', success:'bg-emerald-500', error:'bg-red-500' };
-      const div = document.createElement('div');
-      div.className = `fixed bottom-4 right-4 ${colors[type]} text-white font-bold py-3 px-5 rounded-lg shadow-xl`;
-      div.textContent = message;
-      container.appendChild(div);
-      setTimeout(()=>div.remove(), 2500);
-    }
 
     // Poblar filtro banco
     (function populateBankFilter(){
@@ -219,7 +212,7 @@ export default {
         await attachPage(pageIndex);
       } catch(err){
         console.error(err);
-        toast('Error al cargar datos.', 'error');
+        showToast('Error al cargar datos.', 'error');
       }
     }
 
@@ -383,12 +376,12 @@ export default {
       if (btn.classList.contains('approve-btn')) {
         showModal('¿Aprobar este registro?', async () => {
           await updateDoc(doc(db, transfersCollection.path, id), { status: 'approved', updatedAt: serverTimestamp() });
-          toast('Registro aprobado.', 'success');
+          showToast('Registro aprobado.', 'success');
         });
       } else if (btn.classList.contains('delete-btn')) {
         showModal('¿Eliminar este registro?', async () => {
           await deleteDoc(doc(db, transfersCollection.path, id));
-          toast('Registro eliminado.', 'success');
+          showToast('Registro eliminado.', 'success');
         });
       }
     });

--- a/apps/caja_registrar.app.js
+++ b/apps/caja_registrar.app.js
@@ -7,6 +7,7 @@ import {
 } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
 import { ref, uploadBytes, getDownloadURL } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-storage.js";
 import { toNio } from '../export_utils.js';
+import { showToast } from './lib/toast.js';
 
 export default {
   async mount(container) {
@@ -511,14 +512,6 @@ export default {
     }
 
     // ---------- Utilidades ----------
-    function showToast(message, type='info') {
-      const div = document.createElement('div');
-      const colors = { info:'bg-sky-600', success:'bg-emerald-600', warning:'bg-amber-500', error:'bg-red-600' };
-      div.className = `p-4 rounded-lg shadow-xl text-white font-semibold ${colors[type]}`;
-      div.textContent = message;
-      $('#toast-container').appendChild(div);
-      setTimeout(()=>div.remove(), 3500);
-    }
     const fileToBase64 = (file) => new Promise((res, rej) => {
       const r = new FileReader(); r.onload = e => res(e.target.result); r.onerror = rej; r.readAsDataURL(file);
     });

--- a/apps/compras_editar.app.js
+++ b/apps/compras_editar.app.js
@@ -7,6 +7,7 @@ import { ref, uploadBytes, getDownloadURL }
   from "https://www.gstatic.com/firebasejs/11.6.1/firebase-storage.js";
 import { ItemsEditor } from './components/items_editor.js';
 import { persistMappingsForItems } from './lib/associations.js';
+import { showToast } from './lib/toast.js';
 import { parseNumber } from '../export_utils.js';
 import { DEFAULT_EXCHANGE_RATE } from '../constants.js';
 
@@ -32,16 +33,6 @@ export default {
 
     // ===== Utils =====
     const $  = (sel, root = document) => root.querySelector(sel);
-    function showToast(m, t='success') {
-      let tc = document.getElementById('toast-container');
-      if (!tc) { tc = document.createElement('div'); tc.id='toast-container'; tc.className='fixed bottom-4 right-4 z-50'; document.body.appendChild(tc); }
-      const el = document.createElement('div');
-      const color = t==='success' ? 'bg-emerald-500' : 'bg-red-500';
-      el.className = `toast ${color} text-white font-bold py-3 px-5 rounded-lg shadow-xl transform translate-y-4 opacity-0 fixed bottom-4 right-4 z-50`;
-      el.textContent = m; tc.appendChild(el);
-      setTimeout(()=>{ el.classList.remove('translate-y-4','opacity-0'); }, 10);
-      setTimeout(()=>{ el.classList.add('translate-y-4','opacity-0'); el.addEventListener('transitionend',()=>el.remove()); }, 3000);
-    }
     const ymd = (s) => { const d = new Date(s); if (isNaN(d)) return ''; return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`; };
 
     // ===== IA directa (temporal en frontend) =====

--- a/apps/compras_registrar.app.js
+++ b/apps/compras_registrar.app.js
@@ -7,6 +7,7 @@ import { ref, uploadBytes, getDownloadURL }
   from "https://www.gstatic.com/firebasejs/11.6.1/firebase-storage.js";
 import { ItemsEditor } from './components/items_editor.js';
 import { associateItemsBatch, persistMappingsForItems } from './lib/associations.js';
+import { showToast } from './lib/toast.js';
 import { parseNumber } from '../export_utils.js';
 import { DEFAULT_EXCHANGE_RATE } from '../constants.js';
 
@@ -23,17 +24,6 @@ export default {
 
     // ===== Utils =====
     const $  = (sel, root=document) => root.querySelector(sel);
-
-    function showToast(m,t='success'){
-      let tc = document.getElementById('toast-container');
-      if (!tc) { tc = document.createElement('div'); tc.id='toast-container'; tc.className='fixed bottom-4 right-4 z-50'; document.body.appendChild(tc); }
-      const el=document.createElement('div');
-      const color = t==='success'?'bg-emerald-500':'bg-red-500';
-      el.className = `toast ${color} text-white font-bold py-3 px-5 rounded-lg shadow-xl transform translate-y-4 opacity-0 fixed bottom-4 right-4 z-50`;
-      el.textContent = m; tc.appendChild(el);
-      setTimeout(()=>{el.classList.remove('translate-y-4','opacity-0')},10);
-      setTimeout(()=>{el.classList.add('translate-y-4','opacity-0'); el.addEventListener('transitionend',()=>el.remove())},3000);
-    }
 
     // ===== IA directa (temporal en frontend) =====
     async function getAIDataDirect(base64Array, apiKey) {

--- a/apps/cotizaciones_detalles.app.js
+++ b/apps/cotizaciones_detalles.app.js
@@ -2,6 +2,7 @@
 import {
   doc, getDoc, updateDoc, arrayUnion, serverTimestamp
 } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
+import { showToast } from './lib/toast.js';
 
 const COT_COLLECTION = 'cotizaciones_analizadas';
 
@@ -15,17 +16,6 @@ export default {
     const fCur  = n => `$${(Number(n)||0).toLocaleString('en-US',{minimumFractionDigits:2,maximumFractionDigits:2})}`;
     const fDate = s => { const d=new Date(s); return isNaN(d)? (s||'') :
       `${String(d.getDate()).padStart(2,'0')}-${String(d.getMonth()+1).padStart(2,'0')}-${d.getFullYear()}`; };
-
-    function showToast(m,t='success'){
-      let tc=document.getElementById('toast-container');
-      if(!tc){tc=document.createElement('div');tc.id='toast-container';tc.className='fixed bottom-4 right-4 z-50';document.body.appendChild(tc);}
-      const el=document.createElement('div');
-      const c=t==='success'?'bg-emerald-500':'bg-red-500';
-      el.className=`${c} text-white font-bold py-3 px-5 rounded-lg shadow-xl transform translate-y-4 opacity-0 mb-2`;
-      el.textContent=m; tc.appendChild(el);
-      setTimeout(()=>{el.classList.remove('translate-y-4','opacity-0')},10);
-      setTimeout(()=>{el.classList.add('translate-y-4','opacity-0'); el.addEventListener('transitionend',()=>el.remove())},2800);
-    }
 
     const root = document.createElement('div');
     root.className = 'max-w-6xl mx-auto p-4 md:p-6';

--- a/apps/cotizaciones_editar.app.js
+++ b/apps/cotizaciones_editar.app.js
@@ -4,6 +4,7 @@ import {
 } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
 import { ItemsEditor } from './components/items_editor.js';
 import { persistMappingsForItems } from './lib/associations.js';
+import { showToast } from './lib/toast.js';
 import { parseNumber } from '../export_utils.js';
 import { DEFAULT_EXCHANGE_RATE } from '../constants.js';
 const COT_COLLECTION = 'cotizaciones_analizadas';
@@ -18,17 +19,6 @@ export default {
     if (!id) { container.innerHTML = '<div class="p-6 text-slate-500">ID no especificado.</div>'; return; }
 
     const $ = (s, r=document)=> r.querySelector(s);
-
-    function showToast(m,t='success'){
-      let tc=document.getElementById('toast-container');
-      if(!tc){tc=document.createElement('div');tc.id='toast-container';tc.className='fixed bottom-4 right-4 z-50';document.body.appendChild(tc);}
-      const el=document.createElement('div');
-      const c=t==='success'?'bg-emerald-500':'bg-red-500';
-      el.className=`${c} text-white font-bold py-3 px-5 rounded-lg shadow-xl transform translate-y-4 opacity-0 mb-2`;
-      el.textContent=m; tc.appendChild(el);
-      setTimeout(()=>{el.classList.remove('translate-y-4','opacity-0')},10);
-      setTimeout(()=>{el.classList.add('translate-y-4','opacity-0'); el.addEventListener('transitionend',()=>el.remove())},2800);
-    }
 
     // ===== IA directa (opcional, solo para anexar) =====
     async function getAIDataDirect(base64Array, apiKey) {

--- a/apps/lib/toast.js
+++ b/apps/lib/toast.js
@@ -1,0 +1,34 @@
+const TYPE_COLORS = {
+  success: 'bg-emerald-500',
+  error: 'bg-red-500',
+  info: 'bg-sky-600',
+  warning: 'bg-amber-500'
+};
+
+export function showToast(message, type = 'success') {
+  if (!message) return;
+
+  let container = document.getElementById('toast-container');
+  if (!container) {
+    container = document.createElement('div');
+    container.id = 'toast-container';
+    container.className = 'fixed bottom-4 right-4 z-50';
+    document.body.appendChild(container);
+  }
+
+  const toast = document.createElement('div');
+  const colorClass = TYPE_COLORS[type] || TYPE_COLORS.success;
+  toast.className = `toast ${colorClass} text-white font-bold py-3 px-5 rounded-lg shadow-xl transform translate-y-4 opacity-0 mb-2`;
+  toast.textContent = message;
+  container.appendChild(toast);
+
+  setTimeout(() => {
+    toast.classList.remove('translate-y-4', 'opacity-0');
+  }, 10);
+
+  const removeToast = () => toast.remove();
+  setTimeout(() => {
+    toast.classList.add('translate-y-4', 'opacity-0');
+    toast.addEventListener('transitionend', removeToast, { once: true });
+  }, 3200);
+}


### PR DESCRIPTION
## Summary
- add a shared `showToast` helper in `apps/lib/toast.js` so notifications reuse container setup and styling
- update compras, cotizaciones, caja apps, and standalone HTML flows to import the shared helper instead of duplicating toast logic

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c855b152ec832dbe1f12f6af31fa7b