### PR TITLE
Centralize PDF.js CDN configuration

### DIFF
--- a/app_extraccion.html
+++ b/app_extraccion.html
@@ -136,7 +136,7 @@ input[type="date"]::-webkit-calendar-picker-indicator { cursor: pointer; opacity
     
     <script type="module">
     import { auth, db, storage, firebaseConfig } from './firebase-init.js';
-    import { FIREBASE_BASE } from './apps/lib/constants.js';
+    import { FIREBASE_BASE, PDFJS_CDN } from './apps/lib/constants.js';
     import { onAuthStateChanged, signInAnonymously } from `${FIREBASE_BASE}firebase-auth.js`;
     import { collection, addDoc, serverTimestamp, getDocs, query, where } from `${FIREBASE_BASE}firebase-firestore.js`;
     import { ref, uploadBytes, getDownloadURL } from `${FIREBASE_BASE}firebase-storage.js`;
@@ -967,7 +967,7 @@ Si **NO** es un estado de cuenta con columnas (comprobantes, tickets, vouchers, 
     }
     
     async function renderPdfToImage(file) {
-        pdfjsLib.GlobalWorkerOptions.workerSrc = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.11.338/pdf.worker.min.js`;
+        pdfjsLib.GlobalWorkerOptions.workerSrc = `${PDFJS_CDN}pdf.worker.min.js`;
         const fileReader = new FileReader();
         return new Promise((resolve, reject) => {
             fileReader.onload = async function() {

--- a/apps/caja_registrar.app.js
+++ b/apps/caja_registrar.app.js
@@ -1,7 +1,7 @@
 // /public/apps/caja_registrar.app.js
 // Registrar movimientos de caja (usa colección 'transferencias')
 import { auth, db, storage, firebaseConfig } from '../firebase-init.js';
-import { FIREBASE_BASE } from './lib/constants.js';
+import { FIREBASE_BASE, PDFJS_CDN } from './lib/constants.js';
 import { onAuthStateChanged, signInAnonymously } from `${FIREBASE_BASE}firebase-auth.js`;
 import {
   collection,
@@ -206,13 +206,13 @@ export default {
       if (!window.pdfjsLib) {
         await new Promise((res, rej) => {
           const s = document.createElement('script');
-          s.src = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.11.338/pdf.min.js';
+          s.src = `${PDFJS_CDN}pdf.min.js`;
           s.onload = res; s.onerror = rej;
           document.head.appendChild(s);
         });
       }
       window.pdfjsLib.GlobalWorkerOptions.workerSrc =
-        'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.11.338/pdf.worker.min.js';
+        `${PDFJS_CDN}pdf.worker.min.js`;
 
       const ab = await file.arrayBuffer();
       const pdf = await window.pdfjsLib.getDocument(new Uint8Array(ab)).promise;

--- a/apps/compras_editar.app.js
+++ b/apps/compras_editar.app.js
@@ -1,5 +1,5 @@
 // apps/compras_editar.app.js
-import { FIREBASE_BASE } from './lib/constants.js';
+import { FIREBASE_BASE, PDFJS_CDN } from './lib/constants.js';
 import {
   collection,
   doc,
@@ -75,8 +75,11 @@ export default {
       if (typeof pdfjsLib !== 'undefined') return;
       await new Promise((resolve, reject) => {
         const s = document.createElement('script');
-        s.src = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.11.338/pdf.min.js';
-        s.onload = () => { pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.11.338/pdf.worker.min.js'; resolve(); };
+        s.src = `${PDFJS_CDN}pdf.min.js`;
+        s.onload = () => {
+          pdfjsLib.GlobalWorkerOptions.workerSrc = `${PDFJS_CDN}pdf.worker.min.js`;
+          resolve();
+        };
         s.onerror = reject;
         document.head.appendChild(s);
       });

--- a/apps/compras_registrar.app.js
+++ b/apps/compras_registrar.app.js
@@ -1,5 +1,5 @@
 // apps/compras_registrar.app.js
-import { FIREBASE_BASE } from './lib/constants.js';
+import { FIREBASE_BASE, PDFJS_CDN } from './lib/constants.js';
 import {
   collection,
   addDoc,
@@ -66,8 +66,11 @@ export default {
       if (typeof pdfjsLib !== 'undefined') return;
       await new Promise((resolve, reject)=>{
         const s=document.createElement('script');
-        s.src='https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.11.338/pdf.min.js';
-        s.onload=()=>{ pdfjsLib.GlobalWorkerOptions.workerSrc='https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.11.338/pdf.worker.min.js'; resolve(); };
+        s.src = `${PDFJS_CDN}pdf.min.js`;
+        s.onload = () => {
+          pdfjsLib.GlobalWorkerOptions.workerSrc = `${PDFJS_CDN}pdf.worker.min.js`;
+          resolve();
+        };
         s.onerror=reject; document.head.appendChild(s);
       });
     }

--- a/apps/cotizaciones_editar.app.js
+++ b/apps/cotizaciones_editar.app.js
@@ -1,5 +1,5 @@
 // apps/cotizaciones_editar.app.js
-import { FIREBASE_BASE } from './lib/constants.js';
+import { FIREBASE_BASE, PDFJS_CDN } from './lib/constants.js';
 import {
   doc,
   getDoc,
@@ -47,8 +47,8 @@ export default {
       if (typeof pdfjsLib !== 'undefined') return;
       await new Promise((resolve,reject)=>{
         const s=document.createElement('script');
-        s.src='https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.11.338/pdf.min.js';
-        s.onload=()=>{ pdfjsLib.GlobalWorkerOptions.workerSrc='https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.11.338/pdf.worker.min.js'; resolve(); };
+        s.src=`${PDFJS_CDN}pdf.min.js`;
+        s.onload=()=>{ pdfjsLib.GlobalWorkerOptions.workerSrc=`${PDFJS_CDN}pdf.worker.min.js`; resolve(); };
         s.onerror=reject; document.head.appendChild(s);
       });
     }

--- a/apps/cotizaciones_registrar.app.js
+++ b/apps/cotizaciones_registrar.app.js
@@ -1,5 +1,5 @@
 // apps/cotizaciones_registrar.app.js
-import { FIREBASE_BASE } from './lib/constants.js';
+import { FIREBASE_BASE, PDFJS_CDN } from './lib/constants.js';
 import {
   collection,
   addDoc,
@@ -42,8 +42,8 @@ export default {
 
     async function ensurePdf(){ if(typeof pdfjsLib!=='undefined') return;
       await new Promise((ok,ko)=>{ const s=document.createElement('script');
-        s.src='https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.11.338/pdf.min.js';
-        s.onload=()=>{ pdfjsLib.GlobalWorkerOptions.workerSrc='https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.11.338/pdf.worker.min.js'; ok(); };
+        s.src=`${PDFJS_CDN}pdf.min.js`;
+        s.onload=()=>{ pdfjsLib.GlobalWorkerOptions.workerSrc=`${PDFJS_CDN}pdf.worker.min.js`; ok(); };
         s.onerror=ko; document.head.appendChild(s); });}
     async function pdfToImgs(file){
       await ensurePdf(); const pdf=await pdfjsLib.getDocument({data:await file.arrayBuffer()}).promise;

--- a/apps/lib/constants.js
+++ b/apps/lib/constants.js
@@ -1,4 +1,6 @@
 export const FIREBASE_VERSION = '11.6.1';
 export const FIREBASE_BASE = `https://www.gstatic.com/firebasejs/${FIREBASE_VERSION}/`;
+export const PDFJS_VERSION = '2.11.338';
+export const PDFJS_CDN = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${PDFJS_VERSION}/`;
 export const DEFAULT_EXCHANGE_RATE = 1;
 export const USD_TO_NIO_RATE = 36.6;

--- a/index.html
+++ b/index.html
@@ -10,7 +10,6 @@
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0/dist/chartjs-plugin-datalabels.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.11.338/pdf.min.js"></script>
     <style>
         body { font-family: 'Inter', sans-serif; }
         .nav-link.active {
@@ -88,15 +87,36 @@
 <script type="module">
     import { appState, hydrateDrafts, savePedidoDraft, saveCotizacionDraft } from './state.js';
     import { auth, db as firestoreDb, storage as firebaseStorage } from './firebase-init.js';
-    import { FIREBASE_BASE } from './apps/lib/constants.js';
+    import { FIREBASE_BASE, PDFJS_CDN } from './apps/lib/constants.js';
     import { onAuthStateChanged, signOut } from `${FIREBASE_BASE}firebase-auth.js`;
     import { loadContent } from './app_loader.js';
     import { createRouter } from './framework/router-lite.js';
     import { registry } from './framework/registry.js';
     import { env } from './env.js';
+
+
+
+    const ensurePdfWorker = () => {
+        if (window.pdfjsLib) {
+            window.pdfjsLib.GlobalWorkerOptions.workerSrc = `${PDFJS_CDN}pdf.worker.min.js`;
+        }
+    };
+
+    const existingPdfScript = document.querySelector(`script[src="${PDFJS_CDN}pdf.min.js"]`);
+    if (existingPdfScript) {
+        if (window.pdfjsLib) {
+            ensurePdfWorker();
+        } else {
+            existingPdfScript.addEventListener('load', ensurePdfWorker, { once: true });
+        }
+    } else {
+        const pdfScript = document.createElement('script');
+        pdfScript.src = `${PDFJS_CDN}pdf.min.js`;
+        pdfScript.addEventListener('load', ensurePdfWorker, { once: true });
+        document.head.appendChild(pdfScript);
+    }
+
     
-
-
     // Registro del Service Worker para caché de la app (sin cambios funcionales)
     if ('serviceWorker' in navigator) {
         navigator.serviceWorker.register('/service-worker.js', { scope: '/' })


### PR DESCRIPTION
## Summary
- add shared PDF.js version and CDN constants
- update PDF.js loaders to consume the centralized CDN paths and worker configuration
- dynamically load PDF.js in the dashboard using the shared constants

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c860e2a11c832da05926ea01f225c7