### PR TITLE
Export storage keys and reuse constants

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
     </nav>
 
 <script type="module">
-    import { appState, hydrateDrafts, savePedidoDraft, saveCotizacionDraft } from './state.js';
+    import { appState, hydrateDrafts, savePedidoDraft, saveCotizacionDraft, KEYS } from './state.js';
     import { auth, db as firestoreDb, storage as firebaseStorage } from './firebase-init.js';
     import { FIREBASE_BASE } from './apps/lib/constants.js';
     import { onAuthStateChanged, signOut } from `${FIREBASE_BASE}firebase-auth.js`;
@@ -383,7 +383,7 @@ window.addEventListener('beforeunload', () => {
 });
 
 window.addEventListener('storage', (e) => {
-  if (e.key === 'pedidoDraft:v1' || e.key === 'cotizacionDraft:v1') {
+  if (e.key === KEYS.pedido || e.key === KEYS.cotizacion) {
     hydrateDrafts();
   }
 });

--- a/state.js
+++ b/state.js
@@ -11,7 +11,7 @@ export const appState = {
 };
 
 // Claves de almacenamiento (versionadas por si cambias el formato)
-const KEYS = {
+export const KEYS = {
   pedido: 'pedidoDraft:v1',
   cotizacion: 'cotizacionDraft:v1',
 };


### PR DESCRIPTION
## Summary
- export the storage key constants from `state.js` so they can be reused externally
- update `index.html` to import the shared keys and use them in the storage event listener

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c861648480832d850b939d480dd09c