### PR TITLE
Refactor Tailwind CDN loading

### DIFF
--- a/app_extraccion.html
+++ b/app_extraccion.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Registro de Movimientos</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module" src="./tailwind-loader.js"></script>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 <style>
 .step {

--- a/apps/lib/constants.js
+++ b/apps/lib/constants.js
@@ -2,3 +2,4 @@ export const FIREBASE_VERSION = '11.6.1';
 export const FIREBASE_BASE = `https://www.gstatic.com/firebasejs/${FIREBASE_VERSION}/`;
 export const DEFAULT_EXCHANGE_RATE = 1;
 export const USD_TO_NIO_RATE = 36.6;
+export const TAILWIND_CDN = 'https://cdn.tailwindcss.com';

--- a/apps/mis_pedidos.app.js
+++ b/apps/mis_pedidos.app.js
@@ -1,5 +1,5 @@
 // apps/mis_pedidos.app.js
-import { FIREBASE_BASE } from './lib/constants.js';
+import { FIREBASE_BASE, TAILWIND_CDN } from './lib/constants.js';
 
 export default {
   async mount(container, { appState, auth, db }) {
@@ -209,7 +209,7 @@ export default {
         <html lang="es">
           <head>
             <title>Pedido ${orderId.slice(0,6)}</title>
-            <script src="https://cdn.tailwindcss.com"><\/script>
+            <script src="${TAILWIND_CDN}"><\/script>
             <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
             <style>
               body { font-family: 'Inter', sans-serif; -webkit-print-color-adjust: exact; print-color-adjust: exact; }

--- a/fallback.html
+++ b/fallback.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>Página no encontrada</title>
-  <script src="https://cdn.tailwindcss.com"></script>
+  <script type="module" src="./tailwind-loader.js"></script>
 </head>
 <body class="bg-slate-100 flex items-center justify-center h-screen">
   <div class="text-center p-6 bg-white rounded-lg shadow-md">

--- a/importeAlegra.html
+++ b/importeAlegra.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Panel de Control v4 - Sincronización y Pruebas</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module" src="./tailwind-loader.js"></script>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <style>
         body { font-family: 'Inter', sans-serif; }

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dashboard de Gestión</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module" src="./tailwind-loader.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>

--- a/login.html
+++ b/login.html
@@ -4,8 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Iniciar Sesión</title>
-    
-    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module" src="./tailwind-loader.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     
     <style>

--- a/tailwind-loader.js
+++ b/tailwind-loader.js
@@ -1,0 +1,18 @@
+import { TAILWIND_CDN } from './apps/lib/constants.js';
+
+export function ensureTailwindCdn() {
+  const hasTailwind = Array.from(document.scripts || []).some(
+    (script) => script.src === TAILWIND_CDN || script.dataset?.tailwindCdn === 'true',
+  );
+
+  if (hasTailwind) {
+    return;
+  }
+
+  const tailwindScript = document.createElement('script');
+  tailwindScript.src = TAILWIND_CDN;
+  tailwindScript.dataset.tailwindCdn = 'true';
+  document.head.appendChild(tailwindScript);
+}
+
+ensureTailwindCdn();


### PR DESCRIPTION
## Summary
- add a shared Tailwind CDN constant and loader module to append the stylesheet script once
- update HTML entry points and the print template to consume the constant instead of hardcoding the CDN URL

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c8616db61c832dbe928b19ab0c73d8