### PR TITLE
Fix jefe_caja registry import path

### DIFF
--- a/framework/registry.js
+++ b/framework/registry.js
@@ -19,6 +19,6 @@ export const registry = {
   'cotizaciones_detalles' : () => import('../apps/cotizaciones_detalles.app.js'),
   'cotizaciones_editar'   : () => import('../apps/cotizaciones_editar.app.js'),
   'conciliacion'          : () => import('../apps/conciliacion.app.js'),
-  'jefe_caja'             : () => import('../public/apps/jefe_caja.app.js'),
+  'jefe_caja'             : () => import('../apps/jefe_caja.app.js'),
 
 };


### PR DESCRIPTION
## Summary
- update the jefe_caja registry entry to load the app from the apps directory instead of public/apps

## Testing
- node -e "import('./framework/registry.js').then(r=>{console.log(r.registry['jefe_caja'].toString());});"

------
https://chatgpt.com/codex/tasks/task_e_68c87b58d62c832d8b37e575db103fc8