### PR TITLE
Ensure router forwards query params to mounted apps

### DIFF
--- a/framework/router-lite.js
+++ b/framework/router-lite.js
@@ -11,10 +11,10 @@ export function createRouter({ container, registry, deps = {}, fallbackLoadConte
   function parseRoute(route) {
     const hash = typeof route === 'string' && route ? route : (location.hash || '#/compras_historial');
     const raw = hash.replace(/^#\/?/, '');          // "#/x?y" -> "x?y"
-    const [pathRaw, qs] = raw.split('?');
-    const path = (pathRaw || '').replace(/\/+$/, ''); // quita "/" al final
+    const [pathRaw = '', qs] = raw.split('?');
+    const cleanPath = pathRaw.replace(/\/+$/, ''); // quita "/" al final
     const params = new URLSearchParams(qs || '');
-    return { path, params };
+    return { path: pathRaw, cleanPath, params };
   }
 
   function getLoader(key) {
@@ -34,12 +34,12 @@ export function createRouter({ container, registry, deps = {}, fallbackLoadConte
   }
 
   async function mount(route) {
-    const { path, params } = parseRoute(route);
+    const { cleanPath, params } = parseRoute(route);
 
     await unmount();
     container.innerHTML = '<div class="text-center py-10 text-slate-500">Cargando…</div>';
 
-    const loader = getLoader(path);
+    const loader = getLoader(cleanPath);
     if (loader) {
       try {
         const mod = await loader();


### PR DESCRIPTION
## Summary
- update the router's parseRoute helper to return both the raw and cleaned path along with URLSearchParams params
- ensure mounted apps receive the URLSearchParams instance through the params option while resolving loaders with the cleaned path

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cae2aef5f4832dac97e99fcef43e4e