### PR TITLE
Mantener origen al volver desde detalles de pedido

### DIFF
--- a/apps/creador_pedido.app.js
+++ b/apps/creador_pedido.app.js
@@ -479,7 +479,8 @@ const uiAlert = (message, { title = 'Aviso', variant = 'warning' } = {}) => {
 
       function abrirDetalles(productId) {
         // 100% compatible con el router
-        location.hash = `#/detalles?id=${encodeURIComponent(productId)}`;
+        const from = encodeURIComponent(location.hash || '#/pedidos');
+        location.hash = `#/detalles?id=${encodeURIComponent(productId)}&from=${from}`;
       }
 
       // Ir a la vista "Mis pedidos"

--- a/apps/detalles_articulo.app.js
+++ b/apps/detalles_articulo.app.js
@@ -121,7 +121,7 @@ export default {
 
       container.innerHTML = `
         <div class="p-4 md:p-6 bg-white">
-          <button onclick="history.back()" class="flex items-center text-blue-600 hover:text-blue-800 font-semibold mb-4">
+          <button id="btn-volver" class="flex items-center text-blue-600 hover:text-blue-800 font-semibold mb-4">
             <i class="fas fa-arrow-left mr-2"></i> Volver a la lista
           </button>
           <h2 class="text-2xl font-bold text-gray-800">${product.nombre}</h2>
@@ -162,6 +162,22 @@ export default {
       `;
 
       renderCharts(stats.ventas24, stats.preciosCompraRecientes);
+
+      // Manejo "Volver": si venís con ?from=..., regresá ahí; si no, a #/pedidos
+      const btnVolver = container.querySelector('#btn-volver');
+      if (btnVolver) {
+        btnVolver.addEventListener('click', (e) => {
+          e.preventDefault();
+          const hashSearch = (location.hash.split('?')[1] || '');
+          const qp = new URLSearchParams(hashSearch);
+          const from = qp.get('from');
+          if (from) {
+            location.hash = decodeURIComponent(from);
+          } else {
+            location.hash = '#/pedidos';
+          }
+        });
+      }
     };
 
     // Render inicial


### PR DESCRIPTION
## Summary
- incluir el hash actual como `from` al navegar desde el creador de pedidos al detalle de artículo
- actualizar el botón Volver en la vista de detalles para usar el hash `from` o regresar a `#/pedidos`

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cae3087d6c832dbc8b37272ea1dfa7