### PR TITLE
Preserve query string when mounting routes

### DIFF
--- a/index.html
+++ b/index.html
@@ -454,7 +454,7 @@
             return;
           }
         }
-        await router.mount(route);
+        await router.mount(hash);
         navLinks.forEach(l => l.classList.remove('active'));
         if (navMenu.classList.contains('active')) navMenu.classList.remove('active');
         return;


### PR DESCRIPTION
## Summary
- pass the full hash to `router.mount` so the router keeps query parameters during navigation

## Testing
- node --input-type=module (router hash propagation test)
- node --input-type=module (creador_pedido → detalles navigation test)
- node --input-type=module (detalles heading rendering test)
- node --input-type=module (Volver button return navigation test)

------
https://chatgpt.com/codex/tasks/task_e_68caef48efe8832d8b2ba722394eb6fe