### PR TITLE
Persist 'from' parameter when mounting detalles view

### DIFF
--- a/apps/detalles_articulo.app.js
+++ b/apps/detalles_articulo.app.js
@@ -12,6 +12,9 @@ export default {
     const safeParams = (params instanceof URLSearchParams)
       ? params
       : new URLSearchParams(hashSearch);
+
+    const fromInUrl = safeParams.get('from');
+    if (fromInUrl) sessionStorage.setItem('last_from_pedidos', fromInUrl);
     const productId =
       safeParams.get('id') ||
       safeParams.get('productoId') ||


### PR DESCRIPTION
## Summary
- read the `from` parameter from the URL when mounting the detalles view
- persist the value in sessionStorage so the back navigation works after rerenders

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb006c69dc832d8ff3ef1644c848e7