### PR TITLE
Adjust pedido navigation to creator hash

### DIFF
--- a/apps/creador_pedido.app.js
+++ b/apps/creador_pedido.app.js
@@ -429,7 +429,7 @@ const uiAlert = (message, { title = 'Aviso', variant = 'warning' } = {}) => {
         prov: selectedSupplierName,
         solo: reorderFilterActive ? '1' : '',
       });
-      history.replaceState(null, '', `#/pedidos?${qs.toString()}`);
+      history.replaceState(null, '', `#/creador_pedido?${qs.toString()}`);
     };
 
     // ===== Manejadores de Eventos =====
@@ -499,7 +499,7 @@ const uiAlert = (message, { title = 'Aviso', variant = 'warning' } = {}) => {
 
       function abrirDetalles(productId) {
         // 100% compatible con el router
-        const from = location.hash || '#/pedidos';
+        const from = location.hash || '#/creador_pedido';
         // Guardamos también en sessionStorage por si se pierde el query param
         sessionStorage.setItem('last_from_pedidos', from);
         location.hash = `#/detalles?id=${encodeURIComponent(productId)}&from=${encodeURIComponent(from)}`;

--- a/apps/detalles_articulo.app.js
+++ b/apps/detalles_articulo.app.js
@@ -180,7 +180,7 @@ export default {
 
       renderCharts(stats.ventas24, stats.preciosCompraRecientes);
 
-      // Manejo "Volver": intentar tomar ?from=..., luego sessionStorage, y fallback a #/pedidos
+      // Manejo "Volver": intentar tomar ?from=..., luego sessionStorage, y fallback a #/creador_pedido
       const btnVolver = container.querySelector('#btn-volver');
       if (btnVolver) {
         btnVolver.addEventListener('click', (e) => {
@@ -191,10 +191,10 @@ export default {
           let from = qp.get('from');
 
           if (!from) from = sessionStorage.getItem('last_from_pedidos');
-          if (!from) from = '#/pedidos';
+          if (!from) from = '#/creador_pedido';
 
           try { from = decodeURIComponent(from); } catch (_) {}
-          if (!from.startsWith('#')) from = '#/pedidos';
+          if (!from.startsWith('#')) from = '#/creador_pedido';
 
           location.hash = from;
         });


### PR DESCRIPTION
## Summary
- persist pedidos list filters using the `#/creador_pedido` hash and include it in detail links
- default the detalle "Volver" navigation to `#/creador_pedido` for consistent back navigation

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb0427d61c832d857f4ffc50a6d77b