### PR TITLE
Fix creator route navigation

### DIFF
--- a/apps/cotizaciones_comparar.app.js
+++ b/apps/cotizaciones_comparar.app.js
@@ -170,7 +170,7 @@ export default {
       });
 
       appState.pedidoDraft = { rfqId, items: cart };
-      location.hash = '#/creador-pedido'; // tu app ya imprime/arma el pedido
+      location.hash = '#/creador_pedido'; // tu app ya imprime/arma el pedido
     });
   },
   unmount(){ }


### PR DESCRIPTION
## Summary
- update the "Enviar a Pedido" button so it navigates to the registered `#/creador_pedido` route

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cb2c685b68832d99405bcd7bd793da