### PR TITLE
Normalize router keys for loader lookup

### DIFF
--- a/framework/router-lite.js
+++ b/framework/router-lite.js
@@ -14,7 +14,10 @@ export function createRouter({ container, registry, deps = {}, fallbackLoadConte
     const [pathRaw = '', qs] = raw.split('?');
     const cleanPath = pathRaw.replace(/\/+$/, ''); // quita "/" al final
     const params = new URLSearchParams(qs || '');
-    return { path: pathRaw, cleanPath, params };
+    const normalizedPath = cleanPath
+      .replace(/^\/+|\/+$/g, '') // remove leading/trailing slashes
+      .replace(/-/g, '_');
+    return { path: pathRaw, cleanPath, normalizedPath, params };
   }
 
   function getLoader(key) {
@@ -34,12 +37,12 @@ export function createRouter({ container, registry, deps = {}, fallbackLoadConte
   }
 
   async function mount(route) {
-    const { cleanPath, params } = parseRoute(route);
+    const { cleanPath, normalizedPath, params } = parseRoute(route);
 
     await unmount();
     container.innerHTML = '<div class="text-center py-10 text-slate-500">Cargando…</div>';
 
-    const loader = getLoader(cleanPath);
+    const loader = getLoader(normalizedPath || cleanPath);
     if (loader) {
       try {
         const mod = await loader();


### PR DESCRIPTION
## Summary
- normalize route segments to trim slashes and replace hyphens with underscores before loader lookup
- use the normalized key when resolving registry entries so alternate hashes map to the same module
- manually verified that both `#/jefe_caja` and `#/jefe-caja` mount the registered module instead of the fallback

## Testing
- node - <<'NODE' (custom verification script)


------
https://chatgpt.com/codex/tasks/task_e_68cb97e7db00832d9e5d12154b657a7b