### PR TITLE
Update service worker registration for subpath

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,8 +127,8 @@
 
     // Service Worker
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/service-worker.js', { scope: '/' })
-        .then(reg => console.log('Service Worker OK:', reg.scope))
+      navigator.serviceWorker
+        .register(new URL('./service-worker.js', import.meta.url), { scope: './' })
         .catch(err => console.error('SW error:', err));
     }
 


### PR DESCRIPTION
## Summary
- register the service worker using import.meta.url to support deployment from a subdirectory
- narrow the success handling to rely on the shared failure catch block

## Testing
- playwright smoke test of http://127.0.0.1:8001/subpath/index.html to confirm service worker scope

------
https://chatgpt.com/codex/tasks/task_e_68cb97f3c430832d9211976967967fd3