### PR TITLE
Update toast import path for jefe_caja app

### DIFF
--- a/apps/jefe_caja.app.js
+++ b/apps/jefe_caja.app.js
@@ -12,7 +12,7 @@ import {
   serverTimestamp,
   writeBatch
 } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
-import { showToast } from '../apps/lib/toast.js';
+import { showToast } from './lib/toast.js';
 
 // ⛔️ Eliminado TARGET_ACCOUNTS fijo
 


### PR DESCRIPTION
## Summary
- update the jefe_caja app to import the toast helper using the local ./lib path

## Testing
- node --input-type=module -e "import('./apps/lib/toast.js').then(m=>console.log('toast exports:', Object.keys(m)))"

------
https://chatgpt.com/codex/tasks/task_e_68cb9bf0fa48832da502dc7d32a4fc06