### PR TITLE
Avoid intercepting non-GET or cross-origin requests in SW

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -80,14 +80,12 @@ self.addEventListener('fetch', (event) => {
 
   // 1) No interceptar nada que no sea GET (deja pasar POST: BigQuery, etc.)
   if (req.method !== 'GET') {
-    event.respondWith(fetch(req));
-    return;
+    return; // dejar que el navegador maneje la request normalmente
   }
 
   // 2) No interceptar orígenes externos (CDNs, Google APIs, etc.)
   if (url.origin !== self.location.origin) {
-    event.respondWith(fetch(req));
-    return;
+    return; // no interceptar recursos cross-origin
   }
 
   // 3) BYPASS absoluto para módulos / scripts (evita fallback HTML → error de MIME)


### PR DESCRIPTION
## Summary
- stop the service worker from intercepting non-GET requests so they go straight to the network
- avoid handling cross-origin requests in the service worker and fall back to default browser behavior

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc5a109a2c832db619e2a9bf91c8bc