### PR TITLE
Use Firestore Timestamp when storing purchase comments

### DIFF
--- a/apps/compras_detalles.app.js
+++ b/apps/compras_detalles.app.js
@@ -1,6 +1,6 @@
 // apps/compras_detalles.app.js
 import {
-  doc, getDoc, updateDoc, arrayUnion, serverTimestamp
+  doc, getDoc, updateDoc, arrayUnion, Timestamp
 } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
 import { uploadToStorage as uploadToStorageHelper }
   from '../storage-utils.js';
@@ -260,7 +260,7 @@ export default {
         const txt = root.querySelector('#comment-txt').value.trim();
         if (!txt) return;
         await updateDoc(doc(db,'compras',id), {
-          comments: arrayUnion({ text: txt, authorId: auth?.currentUser?.uid||'anon', createdAt: serverTimestamp() })
+          comments: arrayUnion({ text: txt, authorId: auth?.currentUser?.uid||'anon', createdAt: Timestamp.now() })
         });
         await load(); // recargar
       });


### PR DESCRIPTION
## Summary
- include Firestore Timestamp in compras_detalles app
- store comment timestamps with Timestamp.now to avoid sentinel usage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc60b4e810832d8fa87e1944e66a7d