### PR TITLE
Use Timestamp.now for new comments

### DIFF
--- a/apps/cotizaciones_detalles.app.js
+++ b/apps/cotizaciones_detalles.app.js
@@ -1,6 +1,6 @@
 // apps/cotizaciones_detalles.app.js
 import {
-  doc, getDoc, updateDoc, arrayUnion, serverTimestamp
+  doc, getDoc, updateDoc, arrayUnion, Timestamp
 } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
 import { savePedidoDraft } from '../state.js';
 import { normalizeId, formatMoney } from './lib/helpers.js';
@@ -331,7 +331,7 @@ export default {
         const txt = root.querySelector('#comment-txt').value.trim();
         if (!txt) return;
         await updateDoc(doc(db, COT_COLLECTION,id), {
-          comments: arrayUnion({ text: txt, authorId: auth?.currentUser?.uid || 'anon', createdAt: serverTimestamp() })
+          comments: arrayUnion({ text: txt, authorId: auth?.currentUser?.uid || 'anon', createdAt: Timestamp.now() })
         });
         showToast('Comentario añadido');
         await load();


### PR DESCRIPTION
## Summary
- import the Firestore Timestamp helper for cotización details
- create new comments with Timestamp.now so UI keeps receiving Timestamp objects

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc60bd3f78832d9f159411d05f1855