### PR TITLE
Fix HUD duplication and cleanup in compras detalles app

### DIFF
--- a/apps/compras_detalles.app.js
+++ b/apps/compras_detalles.app.js
@@ -229,8 +229,9 @@ export default {
       `;
 
       // --- HUD flotante (en <body>) ---
-      document.querySelectorAll('.hud-panel').forEach(el => el.remove()); // evita duplicados en recargas parciales
+      document.getElementById('hud-compras-detalle')?.remove(); // evita duplicados entre recargas
       const hud = document.createElement('div');
+      hud.id = 'hud-compras-detalle';            // <<--- id único
       hud.className = 'hud-panel hud-fixed';
       hud.innerHTML = `
         <span class="hud-pair"><span class="lab">Clave:</span> <span class="val" data-k="clave">—</span></span>
@@ -375,7 +376,10 @@ export default {
     }
 
     await load();
-    this._cleanup = () => { try { document.removeEventListener('keydown', onKeyDown); } catch {} };
+    this._cleanup = () => {
+      try { document.removeEventListener('keydown', onKeyDown); } catch {}
+      document.getElementById('hud-compras-detalle')?.remove(); // <<--- elimina el HUD al salir
+    };
   },
   unmount() { try { this._cleanup?.(); } catch {} }
 };


### PR DESCRIPTION
## Summary
- ensure the floating HUD is recreated with a unique id when mounting compras_detalles
- remove the HUD from the document when the app unmounts to avoid leftovers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccc4c28c20832d9914884ac63d2398